### PR TITLE
updated to ImGui v1.44 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ fips_begin_lib(imgui)
         imconfig.h
         imgui.cpp
         imgui.h
+        imgui_demo.cpp
+        imgui_draw.cpp
+        imgui_internal.h
         stb_rect_pack.h
         stb_textedit.h
         stb_truetype.h
@@ -40,6 +43,7 @@ if (NOT FIPS_IMPORT)
             endif()
 
             if (FIPS_MACOS)
+                fips_frameworks_osx(Cocoa CoreVideo OpenGL)
                 fips_libs(m)
             endif()
         fips_end_app()
@@ -61,6 +65,7 @@ if (NOT FIPS_IMPORT)
             endif()
 
             if (FIPS_MACOS)
+                fips_frameworks_osx(Cocoa CoreVideo OpenGL)
                 fips_libs(m dl)
             endif()
         fips_end_app()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ if (NOT FIPS_IMPORT)
 endif()
 
 fips_begin_lib(imgui)
+    fips_vs_disable_warnings(4312)   # 'type cast': conversion from 'int' to 'void *' of greater size
     include_directories(imgui)
     fips_dir(imgui)
     fips_files(


### PR DESCRIPTION
This updates fips-imgui to use imgui v1.44 and also suppresses a new minor warning when compiling in Visual Studio 64-bit mode (a type cast from 32-bit int to a 64-bit void*, which is uncritical).

NOTE: the implementation of the draw callback has changed for imgui 1.44, it will also require a dynamic index buffer update now.
